### PR TITLE
Check world before fiding distance, throwing error

### DIFF
--- a/src/com/m0pt0pmatt/LandPurchasing/Handlers/SignHandler.java
+++ b/src/com/m0pt0pmatt/LandPurchasing/Handlers/SignHandler.java
@@ -42,6 +42,8 @@ public class SignHandler implements Listener {
 			
 			for (LeaseLand plot : LandPurchasing.landManager.getLeasePlots()) {
 				//if (plot.getSignLocation()..equals(clickedLoc)) {
+				if (plot.getSignLocation().getWorld().getName().equals(
+						clickedLoc.getWorld().getName()))
 				if (plot.getSignLocation().distance(clickedLoc) <= 0.1)	{
 					//found it!
 					//send user info, and display the outer shell with glass


### PR DESCRIPTION
Checking the distance between where was clicked and where the sign is throws an error when the worlds aren't the same. This pull just added an additional check before trying to figuring out the distance.